### PR TITLE
feat: add eventbus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,15 +13,15 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -44,10 +44,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
+name = "bitflags"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "examples"
@@ -64,24 +70,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "libc"
-version = "0.2.171"
+name = "io-uring"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c72f6929239626840b28f919ce8981a317fc5dc63ce25c30d2ab372f94886f"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -101,9 +129,9 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -127,15 +155,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -144,12 +178,16 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
+ "io-uring",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "slab",
  "tokio-macros",
 ]
 
@@ -166,9 +204,24 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-targets"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 
 [dev-dependencies]
 qonduit = { path = "../qonduit", features = ["macros"] }
-tokio = { version = "1.44.1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [[example]]
 name = "command"
@@ -15,3 +15,7 @@ path = "command.rs"
 [[example]]
 name = "query"
 path = "query.rs"
+
+[[example]]
+name = "event"
+path = "event.rs"

--- a/examples/event.rs
+++ b/examples/event.rs
@@ -1,0 +1,77 @@
+//! Example demonstrating the event system with multiple handlers (fan-out).
+//!
+//! Run with:
+//!    cargo run --example event
+//!
+//! This shows two equivalent construction styles:
+//! 1. Using the `event_bus!` macro directly
+//! 2. Manually creating an `EventHandlerRegistry` (commented out section)
+//!
+//! Each handler receives a cloned copy of the dispatched event.
+
+use qonduit::async_trait;
+use qonduit::event::{Event, EventHandler};
+use qonduit::event_bus;
+use std::error::Error;
+
+// Domain event representing that a product was created.
+#[derive(Clone, Debug)]
+struct ProductCreatedEvent {
+    id: u64,
+    name: String,
+}
+
+// Implement the marker Event trait.
+impl Event for ProductCreatedEvent {}
+
+// First handler: logs the event.
+struct LoggingHandler;
+
+#[async_trait]
+impl EventHandler<ProductCreatedEvent> for LoggingHandler {
+    async fn handle(&self, event: ProductCreatedEvent) -> Result<(), Box<dyn Error + Send + Sync>> {
+        println!("[log] product created: {} ({})", event.id, event.name);
+        Ok(())
+    }
+}
+
+// Second handler: simulates updating a projection / read model.
+struct ProjectionHandler;
+
+#[async_trait]
+impl EventHandler<ProductCreatedEvent> for ProjectionHandler {
+    async fn handle(&self, event: ProductCreatedEvent) -> Result<(), Box<dyn Error + Send + Sync>> {
+        println!(
+            "[projection] updating read model with product {} ({})",
+            event.id, event.name
+        );
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    // Build an EventBus using the macro (explicit mapping style).
+    let event_bus = event_bus! {
+        ProductCreatedEvent => LoggingHandler,
+        ProductCreatedEvent => ProjectionHandler,
+    };
+
+    // Alternative manual construction (uncomment to use):
+    /*
+    let mut registry = EventHandlerRegistry::new();
+    registry.register::<ProductCreatedEvent>(LoggingHandler);
+    registry.register::<ProductCreatedEvent>(ProjectionHandler);
+    let event_bus = EventBus::new(registry);
+    */
+
+    // Dispatch an event; both handlers will run in registration order.
+    event_bus
+        .dispatch(ProductCreatedEvent {
+            id: 1001,
+            name: "Ergonomic Keyboard".to_string(),
+        })
+        .await?;
+
+    Ok(())
+}

--- a/qonduit/Cargo.toml
+++ b/qonduit/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["asynchronous", "concurrency"]
 authors = ["Iurii Botylev <botylev@protonmail.com"]
 
 [dependencies]
-async-trait = "0.1.88"
+async-trait = "0.1"
 
 [dev-dependencies]
-tokio = { version = "1.44.1", features = ["rt", "macros"] }
+tokio = { version = "1", features = ["rt", "macros"] }
 
 [features]
 default = []

--- a/qonduit/README.md
+++ b/qonduit/README.md
@@ -10,10 +10,12 @@ Qonduit is a Rust implementation of the Command Query Responsibility Segregation
 
 ## Features
 
-- **Command Handling**: Easily define commands that change the state of your system.
-- **Query Handling**: Define queries that retrieve data without modifying the state.
-- **Handler Registration**: Register command and query handlers using convenient macros.
-- **Async Support**: Fully asynchronous handling of commands and queries using `async_trait`.
+- **Command Handling**: Define commands that change the state of your system.
+- **Query Handling**: Retrieve data without mutating state.
+- **Event Handling (Fan-out)**: Publish immutable domain events to multiple handlers (e.g. projections, notifications).
+- **Handler Registration Macros**: `command_bus!`, `query_bus!`, `event_bus!`, and matching `*_registry!` helpers.
+- **Async Support**: Fully asynchronous handling via `async_trait`.
+- **Lightweight & Type-Safe**: Minimal abstractions over strongly typed handlers.
 
 ## Installation
 
@@ -112,6 +114,65 @@ async fn main() {
     }
 }
 ```
+
+## Event System
+
+The event system lets you broadcast immutable domain events to multiple handlers (fan‑out).
+Each handler receives a cloned copy of the event and executes sequentially.
+
+Example:
+
+```rust
+use qonduit::async_trait;
+use qonduit::event::{Event, EventHandler};
+use qonduit::event_bus;
+
+// Define an event
+#[derive(Clone, Debug)]
+struct ProductCreated {
+    id: u64,
+    name: String,
+}
+impl Event for ProductCreated {}
+
+// First handler
+struct LogHandler;
+#[async_trait]
+impl EventHandler<ProductCreated> for LogHandler {
+    async fn handle(&self, e: ProductCreated)
+        -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+    {
+        println!("[log] product created {}", e.id);
+        Ok(())
+    }
+}
+
+// Second handler
+struct ProjectionHandler;
+#[async_trait]
+impl EventHandler<ProductCreated> for ProjectionHandler {
+    async fn handle(&self, e: ProductCreated)
+        -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+    {
+        println!("[projection] updating read model for {}", e.id);
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Build an EventBus with two handlers for the same event type
+    let bus = event_bus! {
+        ProductCreated => LogHandler,
+        ProductCreated => ProjectionHandler,
+    };
+
+    bus.dispatch(ProductCreated { id: 1, name: "Keyboard".into() }).await?;
+    Ok(())
+}
+```
+
+See the `examples/event.rs` example for a more complete version (including manual registry construction).
 
 ## Documentation
 

--- a/qonduit/src/event.rs
+++ b/qonduit/src/event.rs
@@ -1,0 +1,186 @@
+use crate::registry::EventHandlerRegistry;
+use async_trait::async_trait;
+use std::any::Any;
+use std::error::Error;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+/// A domain/event-sourcing style notification that has occurred in the system.
+///
+/// Events are immutable facts - they represent something that already happened.
+/// They are broadcast to all registered handlers. Multiple handlers may react
+/// to the same event type (fan-out).
+///
+/// Implementors should usually be simple data structures (often `struct` with
+/// `#[derive(Clone, Debug)]`). The [`Clone`] bound enables the bus to deliver
+/// the same event instance to multiple handlers.
+///
+/// # Example
+/// ```
+/// use qonduit::event::Event;
+///
+/// #[derive(Clone, Debug)]
+/// struct ProductCreatedEvent {
+///     pub id: u64,
+///     pub name: String,
+/// }
+///
+/// impl Event for ProductCreatedEvent {}
+/// ```
+pub trait Event: Clone + Send + Sync + Any + Debug {}
+
+/// A handler that reacts to an event of type `E`.
+///
+/// Event handlers perform side effects or trigger follow‑up processes in reaction
+/// to events (e.g. sending emails, updating projections, cache invalidation).
+///
+/// Handlers must be idempotent whenever possible because the same event might
+/// be re-dispatched (e.g. in retry scenarios in higher-level architectures).
+///
+/// # Example
+/// ```
+/// use qonduit::async_trait;
+/// use qonduit::event::{Event, EventHandler};
+///
+/// #[derive(Clone, Debug)]
+/// struct InventoryLowEvent {
+///     pub sku: String,
+///     pub remaining: u32,
+/// }
+/// impl Event for InventoryLowEvent {}
+///
+/// struct NotifyTeamHandler;
+///
+/// #[async_trait]
+/// impl EventHandler<InventoryLowEvent> for NotifyTeamHandler {
+///     async fn handle(&self, event: InventoryLowEvent)
+///         -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+///     {
+///         # let _ = event;
+///         // Send a notification to the operations team.
+///         Ok(())
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait EventHandler<E: Event>: Send + Sync {
+    /// Handles (reacts to) an event.
+    ///
+    /// Returning `Ok(())` signals successful processing. Returning an error will
+    /// cause [`EventBus::dispatch`] to propagate the failure (and stop dispatching
+    /// remaining handlers).
+    async fn handle(&self, event: E) -> Result<(), Box<dyn Error + Send + Sync>>;
+}
+
+/// A lightweight publish/subscribe dispatcher for events.
+///
+/// The `EventBus` retrieves all handlers registered for the event's concrete
+/// type and invokes each handler sequentially. Each handler receives a cloned
+/// instance of the event value. If any handler returns an error, dispatching
+/// stops and the error is returned to the caller.
+///
+/// Handlers are stored in an [`EventHandlerRegistry`]. You can construct a bus
+/// manually or via the `event_bus!` macro.
+///
+/// # Example
+/// ```
+/// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+/// # rt.block_on(async {
+/// use qonduit::async_trait;
+/// use qonduit::event::{Event, EventHandler, EventBus};
+/// use qonduit::registry::EventHandlerRegistry;
+///
+/// #[derive(Clone, Debug)]
+/// struct ProductCreatedEvent { id: u64, name: String }
+/// impl Event for ProductCreatedEvent {}
+///
+/// struct LogHandler;
+/// struct ProjectionHandler;
+///
+/// #[async_trait]
+/// impl EventHandler<ProductCreatedEvent> for LogHandler {
+///     async fn handle(&self, e: ProductCreatedEvent)
+///         -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+///     {
+///         println!("LOG: product created {}", e.id);
+///         Ok(())
+///     }
+/// }
+///
+/// #[async_trait]
+/// impl EventHandler<ProductCreatedEvent> for ProjectionHandler {
+///     async fn handle(&self, e: ProductCreatedEvent)
+///         -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+///     {
+///         // Update read model / projection
+///         println!("PROJECTION update for {}", e.id);
+///         Ok(())
+///     }
+/// }
+///
+/// let mut registry = EventHandlerRegistry::new();
+/// registry.register::<ProductCreatedEvent>(LogHandler);
+/// registry.register::<ProductCreatedEvent>(ProjectionHandler);
+///
+/// let bus = EventBus::new(registry);
+/// bus.dispatch(ProductCreatedEvent { id: 1, name: "Keyboard".into() }).await.unwrap();
+/// # });
+/// ```
+#[derive(Clone, Debug)]
+pub struct EventBus {
+    #[doc(hidden)]
+    registry: Arc<EventHandlerRegistry>,
+}
+
+impl EventBus {
+    /// Creates a new `EventBus` backed by the provided registry.
+    pub fn new(registry: EventHandlerRegistry) -> Self {
+        Self {
+            registry: Arc::new(registry),
+        }
+    }
+
+    /// Dispatches (publishes) an event to every registered handler for its type.
+    ///
+    /// Handlers are invoked sequentially in registration order. If a handler
+    /// returns an error, processing stops and that error is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first handler error encountered (if any).
+    ///
+    /// # Example
+    /// ```
+    /// # let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
+    /// # rt.block_on(async {
+    /// use qonduit::async_trait;
+    /// use qonduit::event::{Event, EventHandler, EventBus};
+    /// use qonduit::registry::EventHandlerRegistry;
+    ///
+    /// #[derive(Clone, Debug)]
+    /// struct OrderPaidEvent { order_id: u64 }
+    /// impl Event for OrderPaidEvent {}
+    ///
+    /// struct IndexHandler;
+    /// #[async_trait]
+    /// impl EventHandler<OrderPaidEvent> for IndexHandler {
+    ///     async fn handle(&self, e: OrderPaidEvent)
+    ///         -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    ///         # let _ = e;
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// let mut registry = EventHandlerRegistry::new();
+    /// registry.register::<OrderPaidEvent>(IndexHandler);
+    /// let bus = EventBus::new(registry);
+    /// bus.dispatch(OrderPaidEvent { order_id: 42 }).await.unwrap();
+    /// # });
+    /// ```
+    pub async fn dispatch<E: Event>(&self, event: E) -> Result<(), Box<dyn Error + Send + Sync>> {
+        for handler in self.registry.get_handlers::<E>() {
+            handler.handle(event.clone()).await?;
+        }
+        Ok(())
+    }
+}

--- a/qonduit/tests/event_tests.rs
+++ b/qonduit/tests/event_tests.rs
@@ -1,0 +1,191 @@
+use qonduit::async_trait;
+use qonduit::event::{Event, EventBus, EventHandler};
+use qonduit::registry::EventHandlerRegistry;
+use std::error::Error;
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::Ordering::SeqCst;
+
+#[derive(Debug, Clone)]
+struct TestEvent();
+impl Event for TestEvent {}
+
+struct TestEventHandler;
+
+#[async_trait]
+impl EventHandler<TestEvent> for TestEventHandler {
+    async fn handle(&self, _event: TestEvent) -> Result<(), Box<dyn Error + Send + Sync>> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_event_bus_successful_dispatch() {
+    // Create registry and register handler
+    let mut registry = EventHandlerRegistry::new();
+    registry.register::<TestEvent>(TestEventHandler);
+
+    // Create bus with registry
+    let bus = EventBus::new(registry);
+
+    // Dispatch event
+    let result = bus.dispatch(TestEvent()).await;
+
+    // Check result
+    assert!(result.is_ok());
+}
+
+// ===== Event Registry Tests =====
+
+// Event type 1 for registry tests
+#[derive(Debug, Clone)]
+struct Event1();
+
+impl Event for Event1 {}
+
+struct Event1Handler;
+
+#[async_trait]
+impl EventHandler<Event1> for Event1Handler {
+    async fn handle(&self, _event: Event1) -> Result<(), Box<dyn Error + Send + Sync>> {
+        Ok(())
+    }
+}
+
+// Event type 2 for registry tests
+#[derive(Debug, Clone)]
+struct Event2();
+
+impl Event for Event2 {}
+
+struct Event2Handler;
+
+#[async_trait]
+impl EventHandler<Event2> for Event2Handler {
+    async fn handle(&self, _event: Event2) -> Result<(), Box<dyn Error + Send + Sync>> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_event_registry_empty() {
+    let registry = EventHandlerRegistry::new();
+    assert!(registry.get_handlers::<Event1>().is_empty());
+}
+
+#[tokio::test]
+async fn test_event_registry_single_registration() {
+    let mut registry = EventHandlerRegistry::new();
+
+    // Initially no handler is registered
+    assert!(registry.get_handlers::<Event1>().is_empty());
+
+    // Register a handler
+    registry.register::<Event1>(Event1Handler);
+
+    // Now a handler should be available
+    let handler = registry.get_handlers::<Event1>();
+    assert!(!handler.is_empty());
+
+    // The handler should work correctly
+    let result = handler.get(0).unwrap().handle(Event1()).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_event_registry_multiple_registrations() {
+    let mut registry = EventHandlerRegistry::new();
+
+    // Register multiple handlers
+    registry.register::<Event1>(Event1Handler);
+    registry.register::<Event2>(Event2Handler);
+
+    // Both handlers should be available
+    assert!(!registry.get_handlers::<Event1>().is_empty());
+    assert!(!registry.get_handlers::<Event2>().is_empty());
+
+    // Test Event1 handler
+    let handlers1 = registry.get_handlers::<Event1>();
+    let result1 = handlers1.get(0).unwrap().handle(Event1()).await;
+    assert!(result1.is_ok());
+
+    // Test Event2 handler
+    let handlers2 = registry.get_handlers::<Event2>();
+    let result2 = handlers2.get(0).unwrap().handle(Event2()).await;
+    assert!(result2.is_ok());
+}
+
+#[derive(Debug, Clone)]
+struct IncEvent(pub u32);
+impl Event for IncEvent {}
+
+struct IncEventHandler {
+    pub counter: Arc<AtomicU32>,
+}
+
+#[async_trait]
+impl EventHandler<IncEvent> for IncEventHandler {
+    async fn handle(&self, event: IncEvent) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.counter.fetch_add(event.0, SeqCst);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_event_bus_successful_dispatch_inc_single() {
+    let counter = Arc::new(AtomicU32::new(0));
+    let handler = IncEventHandler {
+        counter: counter.clone(),
+    };
+    // Create registry and register handler
+    let mut registry = EventHandlerRegistry::new();
+    registry.register::<IncEvent>(handler);
+
+    // Create bus with registry
+    let bus = EventBus::new(registry);
+
+    // Dispatch event
+    let result = bus.dispatch(IncEvent(1)).await;
+
+    // Check result
+    assert!(result.is_ok());
+    assert_eq!(counter.load(SeqCst), 1);
+
+    let result = bus.dispatch(IncEvent(2)).await;
+
+    // Check result
+    assert!(result.is_ok());
+    assert_eq!(counter.load(SeqCst), 3);
+}
+
+#[tokio::test]
+async fn test_event_bus_successful_dispatch_inc_multiple() {
+    let counter = Arc::new(AtomicU32::new(0));
+    let handler1 = IncEventHandler {
+        counter: counter.clone(),
+    };
+    let handler2 = IncEventHandler {
+        counter: counter.clone(),
+    };
+    // Create registry and register handler
+    let mut registry = EventHandlerRegistry::new();
+    registry.register::<IncEvent>(handler1);
+    registry.register::<IncEvent>(handler2);
+
+    // Create bus with registry
+    let bus = EventBus::new(registry);
+
+    // Dispatch event
+    let result = bus.dispatch(IncEvent(1)).await;
+
+    // Check result
+    assert!(result.is_ok());
+    assert_eq!(counter.load(SeqCst), 2);
+
+    let result = bus.dispatch(IncEvent(2)).await;
+
+    // Check result
+    assert!(result.is_ok());
+    assert_eq!(counter.load(SeqCst), 6);
+}


### PR DESCRIPTION
This pull request adds an event system to the qonduit library. This system allows immutable events to be dispatched to multiple handlers, each receiving a cloned event instance. The system supports both macro-based and manual handler registration.

- Relaxed the version constraints for `tokio` and `async-trait` dependencies in both the main crate and examples to allow for broader compatibility